### PR TITLE
Popravek 08-predstavitve.md

### DIFF
--- a/ucbenik/08-predstavitve.md
+++ b/ucbenik/08-predstavitve.md
@@ -58,9 +58,9 @@ Prehajanje med izvorno kodo v `.tex` datoteki in PDF datoteko v VSCode:
     če jih lahko razbijemo na manjše. 
     Tako bomo naredili tudi tokrat.
     Pod ukazom `section` z naslovom Paket `beamer` prilepite ukaz
-    `\input{prosojnice-resitve/1-paket-beamer.tex}`.
+    `\input{prosojnice/1-paket-beamer.tex}`.
     Ta ukaz vključi vsebino datoteke `1-paket-beamer.tex`, ki se nahaja v imeniku
-    `1-paket-beamer.tex`.
+    `prosojnice`.
     Parametru, ki smo ga podali ukazu `input`, to je `prosojnice-resitve/1-paket-beamer.tex`,
     rečemo **relativna pot**, saj podamo navodila, kako od datoteke z ukazom `input` 
     (v tem primer `prosojnice.tex`) pridemo do datoteke, ki jo vključujemo.


### PR DESCRIPTION
V "2. Vključevanje datotek in posebnosti predstavitev" so sledeče  napake:
V zipu, ki ga potegnemo iz spletne učilnice se imenik imenuje "prosojnice" in ne "prosojnice-rešitev" zato ukaz "\input{prosojnice-resitve/1-paket-beamer.tex}" nebo deloval. Prav tako je narobe napisano da je "1-paket-beamer.tex" v imeniku "1-paket-beamer.tex" kar je napaka.